### PR TITLE
Update MinGW compilers

### DIFF
--- a/builders.py
+++ b/builders.py
@@ -64,11 +64,9 @@ def get_builders():
         make_builder('debian-gcc-64', ['master-debian-64', 'binary1248-debian-64'], 'tmp', 'Unix Makefiles', 'make', '', '', '', ''),
         make_builder('freebsd-gcc-64', ['zsbzsb-freebsd-64', 'binary1248-freebsd-64'], 'tmp', 'Unix Makefiles', 'make', '', '', '', ''),
         make_builder('osx-clang-universal', ['hiura-osx'], 'tmp', 'Unix Makefiles', 'make', '', '', '', ''),
-        make_builder('windows-gcc-471-tdm-32', ['master-windows', 'expl0it3r-windows'], 'tmp', 'MinGW Makefiles', 'mingw32-make', paths.gcc471tdm32path, '', '', ''),
-        make_builder('windows-gcc-471-tdm-64', ['master-windows', 'expl0it3r-windows'], 'tmp', 'MinGW Makefiles', 'mingw32-make', paths.gcc471tdm64path, '', '', ''),
-        make_builder('windows-gcc-481-tdm-32', ['master-windows', 'expl0it3r-windows'], 'tmp', 'MinGW Makefiles', 'mingw32-make', paths.gcc481tdm32path, '', '', ''),
-        make_builder('windows-gcc-481-tdm-64', ['master-windows', 'expl0it3r-windows'], 'tmp', 'MinGW Makefiles', 'mingw32-make', paths.gcc481tdm64path, '', '', ''),
-        make_builder('windows-gcc-520-mingw-32', ['master-windows', 'expl0it3r-windows'], 'tmp', 'MinGW Makefiles', 'mingw32-make', paths.gcc520mingw32path, '', '', ''),
-        make_builder('windows-gcc-520-mingw-64', ['master-windows', 'expl0it3r-windows'], 'tmp', 'MinGW Makefiles', 'mingw32-make', paths.gcc520mingw64path, '', '', ''),
+        make_builder('windows-gcc-492-tdm-32', ['master-windows', 'expl0it3r-windows'], 'tmp', 'MinGW Makefiles', 'mingw32-make', paths.gcc492tdm32path, '', '', ''),
+        make_builder('windows-gcc-492-tdm-64', ['master-windows', 'expl0it3r-windows'], 'tmp', 'MinGW Makefiles', 'mingw32-make', paths.gcc492tdm64path, '', '', ''),
+        make_builder('windows-gcc-530-mingw-32', ['master-windows', 'expl0it3r-windows'], 'tmp', 'MinGW Makefiles', 'mingw32-make', paths.gcc530mingw32path, '', '', ''),
+        make_builder('windows-gcc-530-mingw-64', ['master-windows', 'expl0it3r-windows'], 'tmp', 'MinGW Makefiles', 'mingw32-make', paths.gcc530mingw64path, '', '', ''),
         make_static_analysis_builder('static-analysis', ['binary1248-debian-64'], 'tmp')
     ]

--- a/paths.py
+++ b/paths.py
@@ -250,14 +250,10 @@ vc14x64libpath = (
     'C:/Program Files (x86)/Microsoft SDKs/Windows Kits/10/ExtensionSDKs/Microsoft.VCLibs/14.0/References/CommonConfiguration/neutral;'
 )
 
-gcc471tdm32path = 'C:/Dev/MinGW32-TDM471/bin/;'
+gcc492tdm32path = 'C:/Dev/MinGW32-TDM492/bin/;'
 
-gcc471tdm64path = 'C:/Dev/MinGW64-TDM471/bin/;'
+gcc492tdm64path = 'C:/Dev/MinGW64-TDM492/bin/;'
 
-gcc481tdm32path = 'C:/Dev/MinGW32-TDM481/bin/;'
+gcc530mingw32path = 'C:/Dev/MinGW32-PosixDwarf530r0/bin/;'
 
-gcc481tdm64path = 'C:/Dev/MinGW64-TDM481/bin/;'
-
-gcc520mingw32path = 'C:/Dev/MinGW32-PosixDwarf520r0/bin/;'
-
-gcc520mingw64path = 'C:/Dev/MinGW64-PosixSEH520r0/bin/;'
+gcc530mingw64path = 'C:/Dev/MinGW64-PosixSEH530r0/bin/;'


### PR DESCRIPTION
- Removed the four sets of TDM compilers.
- Added the newer TDM compiler shipped with Code::Blocks.
- Updated the MinGW Builds compiler from GCC 5.2.0 to 5.3.0

Since I'm not that familiar with the files, I'm not sure if I got all the places that needed changes.
