### PR TITLE
Use cmake build command wrapper, and add iOS build

### DIFF
--- a/builders.py
+++ b/builders.py
@@ -9,7 +9,7 @@ def slavePriority(builder, slaves):
 def get_builder_names():
     return builder_names
 
-def make_builder(builder_name, slaves, generator, maker, toolchain_path, vc_include, vc_lib, vc_libpath, artifact):
+def make_builder(builder_name, slaves, generator, toolchain_path, vc_include, vc_lib, vc_libpath, artifact):
     from buildbot.config import BuilderConfig
     import buildfactories
 
@@ -31,7 +31,6 @@ def make_builder(builder_name, slaves, generator, maker, toolchain_path, vc_incl
         factory = buildfactories.get_build_factory(builder_name),
         properties = {
             'generator' : generator,
-            'maker' : maker,
             'toolchain_path' : toolchain_path,
             'vc_include' : vc_include,
             'vc_lib' : vc_lib,
@@ -49,19 +48,20 @@ def get_builders():
     import paths
 
     return [
-        make_builder('windows-vc11-32', ['master-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', 'jom', paths.vc11x86path, paths.vc11x86include, paths.vc11x86lib, paths.vc11x86libpath, True),
-        make_builder('windows-vc11-64', ['master-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', 'jom', paths.vc11x64path, paths.vc11x64include, paths.vc11x64lib, paths.vc11x64libpath, True),
-        make_builder('windows-vc12-32', ['master-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', 'jom', paths.vc12x86path, paths.vc12x86include, paths.vc12x86lib, paths.vc12x86libpath, True),
-        make_builder('windows-vc12-64', ['master-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', 'jom', paths.vc12x64path, paths.vc12x64include, paths.vc12x64lib, paths.vc12x64libpath, True),
-        make_builder('windows-vc14-32', ['master-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', 'jom', paths.vc14x86path, paths.vc14x86include, paths.vc14x86lib, paths.vc14x86libpath, True),
-        make_builder('windows-vc14-64', ['master-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', 'jom', paths.vc14x64path, paths.vc14x64include, paths.vc14x64lib, paths.vc14x64libpath, True),
-        make_builder('windows-gcc-492-tdm-32', ['binary1248-windows', 'master-windows', 'expl0it3r-windows'], 'MinGW Makefiles', 'mingw32-make', paths.gcc492tdm32path, '', '', '', True),
-        make_builder('windows-gcc-492-tdm-64', ['binary1248-windows', 'master-windows', 'expl0it3r-windows'], 'MinGW Makefiles', 'mingw32-make', paths.gcc492tdm64path, '', '', '', True),
-        make_builder('windows-gcc-630-mingw-32', ['binary1248-windows', 'master-windows', 'expl0it3r-windows'], 'MinGW Makefiles', 'mingw32-make', paths.gcc630mingw32path, '', '', '', True),
-        make_builder('windows-gcc-630-mingw-64', ['binary1248-windows', 'master-windows', 'expl0it3r-windows'], 'MinGW Makefiles', 'mingw32-make', paths.gcc630mingw64path, '', '', '', True),
-        make_builder('debian-gcc-64', ['binary1248-debian-64', 'master-debian-64'], 'Unix Makefiles', 'make', '', '', '', '', True),
-        make_builder('android-armeabi-v7a-api13', ['binary1248-debian-64'], 'Unix Makefiles', 'make', '', '', '', '', True),
-        make_builder('static-analysis', ['binary1248-debian-64'], 'Unix Makefiles', 'make', '', '', '', '', False),
-        make_builder('freebsd-gcc-64', ['binary1248-freebsd-64', 'zsbzsb-freebsd-64'], 'Unix Makefiles', 'make', '', '', '', '', False),
-        make_builder('osx-clang-el-capitan', ['hiura-osx'], 'Unix Makefiles', 'make', '', '', '', '', True)
+        make_builder('windows-vc11-32', ['master-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc11x86path, paths.vc11x86include, paths.vc11x86lib, paths.vc11x86libpath, True),
+        make_builder('windows-vc11-64', ['master-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc11x64path, paths.vc11x64include, paths.vc11x64lib, paths.vc11x64libpath, True),
+        make_builder('windows-vc12-32', ['master-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc12x86path, paths.vc12x86include, paths.vc12x86lib, paths.vc12x86libpath, True),
+        make_builder('windows-vc12-64', ['master-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc12x64path, paths.vc12x64include, paths.vc12x64lib, paths.vc12x64libpath, True),
+        make_builder('windows-vc14-32', ['master-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc14x86path, paths.vc14x86include, paths.vc14x86lib, paths.vc14x86libpath, True),
+        make_builder('windows-vc14-64', ['master-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc14x64path, paths.vc14x64include, paths.vc14x64lib, paths.vc14x64libpath, True),
+        make_builder('windows-gcc-492-tdm-32', ['binary1248-windows', 'master-windows', 'expl0it3r-windows'], 'MinGW Makefiles', paths.gcc492tdm32path, '', '', '', True),
+        make_builder('windows-gcc-492-tdm-64', ['binary1248-windows', 'master-windows', 'expl0it3r-windows'], 'MinGW Makefiles', paths.gcc492tdm64path, '', '', '', True),
+        make_builder('windows-gcc-630-mingw-32', ['binary1248-windows', 'master-windows', 'expl0it3r-windows'], 'MinGW Makefiles', paths.gcc630mingw32path, '', '', '', True),
+        make_builder('windows-gcc-630-mingw-64', ['binary1248-windows', 'master-windows', 'expl0it3r-windows'], 'MinGW Makefiles', paths.gcc630mingw64path, '', '', '', True),
+        make_builder('debian-gcc-64', ['binary1248-debian-64', 'master-debian-64'], 'Unix Makefiles', '', '', '', '', True),
+        make_builder('android-armeabi-v7a-api13', ['binary1248-debian-64'], 'Unix Makefiles', '', '', '', '', True),
+        make_builder('static-analysis', ['binary1248-debian-64'], 'Unix Makefiles', '', '', '', '', False),
+        make_builder('freebsd-gcc-64', ['binary1248-freebsd-64', 'zsbzsb-freebsd-64'], 'Unix Makefiles', '', '', '', '', False),
+        make_builder('osx-clang-el-capitan', ['hiura-osx'], 'Unix Makefiles', '', '', '', '', True),
+        make_builder('ios-clang-el-capitan', ['hiura-osx'], 'Xcode', '', '', '', '', True)
     ]


### PR DESCRIPTION
Following on from #9 I've added the iOS build, tested on my machine (macOS 10.13, Xcode 9) running the same version of buildbot.

This also removes the dependency on makefile generators and uses the cmake build command, so adding extra generators will hopefully be easier in future.

I should probably mention Python isn't my first language and iOS isn't my first platform, but hopefully this helps in some way.
  