### PR TITLE
Remove arm64 flag for iOS builds

### DIFF
--- a/buildfactories.py
+++ b/buildfactories.py
@@ -121,10 +121,6 @@ def get_build_step(link, type, options = []):
         else:
             build_command += ' --config Release'
 
-    # iOS build uses arch arm64
-    if 'ios' in options:
-        build_command += ' -- -arch arm64'
-
     return Compile(
         description = ['building'],
         descriptionSuffix = suffix,


### PR DESCRIPTION
[As mentioned by](https://github.com/SFML/SFML/pull/1378#issuecomment-379012417) @Ceylo this flag needs to be removed.

@JonnyPtn 