### PR TITLE
Add support for VS 2019 and MinGW 8.1.0

### DIFF
--- a/builders.py
+++ b/builders.py
@@ -66,15 +66,14 @@ def get_builders():
     import paths
 
     return [
-        make_builder('windows-vc12-32', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc12path, 'x86', True, True),
-        make_builder('windows-vc12-64', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc12path, 'amd64', True, True),
         make_builder('windows-vc14-32', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc14path, 'x86', True, True),
         make_builder('windows-vc14-64', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc14path, 'amd64', True, True),
         make_builder('windows-vc15-32', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc15path, 'x86', True, True),
         make_builder('windows-vc15-64', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc15path, 'amd64', True, True),
-        make_builder('windows-gcc-510-tdm-32', ['binary1248-windows', 'expl0it3r-windows'], 'MinGW Makefiles', paths.gcc510tdm32path, '', True, True),
-        make_builder('windows-gcc-730-mingw-32', ['binary1248-windows', 'expl0it3r-windows'], 'MinGW Makefiles', paths.gcc730mingw32path, '', True, True),
-        make_builder('windows-gcc-730-mingw-64', ['binary1248-windows', 'expl0it3r-windows'], 'MinGW Makefiles', paths.gcc730mingw64path, '', True, True),
+        make_builder('windows-vc16-32', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc16path, 'x86', True, True),
+        make_builder('windows-vc16-64', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc16path, 'amd64', True, True),
+        make_builder('windows-gcc-810-mingw-32', ['binary1248-windows', 'expl0it3r-windows'], 'MinGW Makefiles', paths.gcc810mingw32path, '', True, True),
+        make_builder('windows-gcc-810-mingw-64', ['binary1248-windows', 'expl0it3r-windows'], 'MinGW Makefiles', paths.gcc810mingw64path, '', True, True),
         make_builder('debian-gcc-64', ['binary1248-debian-64'], 'Unix Makefiles', '', '', True, True),
         make_builder('android-armeabi-v7a-api13', ['binary1248-debian-64'], 'Unix Makefiles', '', '', True, False),
         make_builder('static-analysis', ['binary1248-debian-64'], 'Unix Makefiles', '', '', False, False),

--- a/paths.py
+++ b/paths.py
@@ -1,8 +1,3 @@
-vc12path = (
-    'C:/Dev/tools;'
-    'C:/Program Files (x86)/Microsoft Visual Studio 12.0/VC;'
-)
-
 vc14path = (
     'C:/Dev/tools;'
     'C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC;'
@@ -13,8 +8,11 @@ vc15path = (
     'C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build;'
 )
 
-gcc510tdm32path = 'C:/Dev/MinGW32-TDM510/bin/;'
+vc16path = (
+    'C:/Dev/tools;'
+    'C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Auxiliary/Build;'
+)
 
-gcc730mingw32path = 'C:/Dev/MinGW32-PosixDwarf730r0/bin/;'
+gcc810mingw32path = 'C:/Dev/MinGW32-Win32Dwarf810r0/bin/;'
 
-gcc730mingw64path = 'C:/Dev/MinGW64-PosixSEH730r0/bin/;'
+gcc810mingw64path = 'C:/Dev/MinGW64-Win32SEH810r0/bin/;'

--- a/project.py
+++ b/project.py
@@ -2,7 +2,7 @@ def get_title():
     return 'SFML'
 
 def get_title_url():
-    return 'http://www.sfml-dev.org'
+    return 'https://www.sfml-dev.org'
 
 def get_buildbot_url():
     return 'https://ci.sfml-dev.org/'


### PR DESCRIPTION
- Remove VS 2014
- Update MinGW from 7.3.0 to 8.1.0
- Remove the Code::Blocks TDM build

Update required for the upcoming release(s).

New compilers:

- [MinGW 64-bits](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-win32/seh/)
- [MinGW 32-bits](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/8.1.0/threads-win32/dwarf/)
- [VS 2019](https://visualstudio.microsoft.com/vs/)