### PR TITLE
Update macOS builder names

### DIFF
--- a/builders.py
+++ b/builders.py
@@ -78,6 +78,6 @@ def get_builders():
         make_builder('android-armeabi-v7a-api13', ['binary1248-debian-64'], 'Unix Makefiles', '', '', True, False),
         make_builder('static-analysis', ['binary1248-debian-64'], 'Unix Makefiles', '', '', False, False),
         make_builder('freebsd-gcc-64', ['binary1248-freebsd-64'], 'Unix Makefiles', '', '', False, True),
-        make_builder('osx-clang-el-capitan', ['hiura-osx'], 'Unix Makefiles', '', '', True, True),
-        make_builder('ios-clang-el-capitan', ['hiura-osx'], 'Xcode', '', '', True, False)
+        make_builder('osx-clang', ['macos'], 'Unix Makefiles', '', '', True, True),
+        make_builder('ios-clang', ['macos'], 'Xcode', '', '', True, False)
     ]

--- a/buildslaves.py
+++ b/buildslaves.py
@@ -11,7 +11,7 @@ def get_slaves():
     return [
         Worker('unassigned', private.slave_passwords['unassigned'], max_builds = 1, properties = {'parallel' : 0}),
         Worker('expl0it3r-windows', private.slave_passwords['expl0it3r-windows'], properties = {'parallel' : 1}),
-        Worker('hiura-osx', private.slave_passwords['hiura-osx'], max_builds = 1, properties = {'parallel' : 3}),
+        Worker('macos', private.slave_passwords['macos'], max_builds = 1, properties = {'parallel' : 3}),
         Worker('binary1248-debian-64', private.slave_passwords['binary1248-debian-64'], max_builds = 1, properties = {'parallel' : 5}),
         Worker('binary1248-freebsd-64', private.slave_passwords['binary1248-freebsd-64'], max_builds = 1, properties = {'parallel' : 1}),
         Worker('binary1248-windows', private.slave_passwords['binary1248-windows'], max_builds = 1, properties = {'parallel' : 8})

--- a/private.py.in
+++ b/private.py.in
@@ -5,7 +5,7 @@ port = <port redacted>
 slave_passwords = dict([
 	('unassigned',            '<password redacted>'),
 	('expl0it3r-windows',     '<password redacted>'),
-	('hiura-osx',             '<password redacted>'),
+	('macos',                 '<password redacted>'),
 	('master',                '<password redacted>'),
 	('master-debian-64',      '<password redacted>'),
 	('master-ubuntu-64',      '<password redacted>'),


### PR DESCRIPTION
The macOS version was updated to Big Sur, so the El Capitan doesn't
really make sense anymore.