### PR TITLE
Disable tests for macos-arm64 for now

### DIFF
--- a/builders.py
+++ b/builders.py
@@ -81,5 +81,5 @@ def get_builders():
         make_builder('freebsd-gcc-64', ['binary1248-freebsd-64'], 'Unix Makefiles', '', '', False, True),
         make_builder('macos-clang-64', ['macos-64'], 'Unix Makefiles', '', 'x86_64', True, True),
         make_builder('ios-clang-64', ['macos-64'], 'Xcode', '', '', True, False),
-        make_builder('macos-clang-arm64', ['macos-arm64'], 'Unix Makefiles', '', 'arm64', True, True),
+        make_builder('macos-clang-arm64', ['macos-arm64'], 'Unix Makefiles', '', 'arm64', True, False),
     ]


### PR DESCRIPTION
The Catch testing framework needs to be updated, which requires the C++ standard to be raised, etc.
It's easier to disable the tests for now.