### PR TITLE
Replace VS 2015 with VS 2022

### DIFF
--- a/builders.py
+++ b/builders.py
@@ -66,12 +66,12 @@ def get_builders():
     import paths
 
     return [
-        make_builder('windows-vc14-32', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc14path, 'x86', True, True),
-        make_builder('windows-vc14-64', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc14path, 'amd64', True, True),
         make_builder('windows-vc15-32', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc15path, 'x86', True, True),
         make_builder('windows-vc15-64', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc15path, 'amd64', True, True),
         make_builder('windows-vc16-32', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc16path, 'x86', True, True),
         make_builder('windows-vc16-64', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc16path, 'amd64', True, True),
+        make_builder('windows-vc17-32', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc17path, 'x86', True, True),
+        make_builder('windows-vc17-64', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc17path, 'amd64', True, True),
         make_builder('windows-gcc-810-mingw-32', ['binary1248-windows', 'expl0it3r-windows'], 'MinGW Makefiles', paths.gcc810mingw32path, '', True, True),
         make_builder('windows-gcc-810-mingw-64', ['binary1248-windows', 'expl0it3r-windows'], 'MinGW Makefiles', paths.gcc810mingw64path, '', True, True),
         make_builder('debian-gcc-64', ['binary1248-debian-64'], 'Unix Makefiles', '', '', True, True),

--- a/paths.py
+++ b/paths.py
@@ -1,8 +1,3 @@
-vc14path = (
-    'C:/Dev/tools;'
-    'C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC;'
-)
-
 vc15path = (
     'C:/Dev/tools;'
     'C:/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/VC/Auxiliary/Build;'
@@ -11,6 +6,11 @@ vc15path = (
 vc16path = (
     'C:/Dev/tools;'
     'C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Auxiliary/Build;'
+)
+
+vc17path = (
+    'C:/Dev/tools;'
+    'C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Auxiliary/Build;'
 )
 
 gcc810mingw32path = 'C:/Dev/MinGW32-Win32Dwarf810r0/bin/;'


### PR DESCRIPTION
Note: VS 2022 is (finally) the first 64-bits application, so it resides in the "Program Files" directory.