### PR TITLE
Update macOS SDK target to 10.12

### DIFF
--- a/buildfactories.py
+++ b/buildfactories.py
@@ -52,9 +52,9 @@ def get_cmake_step(link, type, options = []):
         suffix = [link, type]
 
     if 'newSDK' in options:
-        build_target += '-DCMAKE_OSX_DEPLOYMENT_TARGET=10.11'
+        build_target += '-DCMAKE_OSX_DEPLOYMENT_TARGET=10.12'
         # the SDK is set by CMake
-        suffix.append('10.11')
+        suffix.append('10.12')
 
     if 'android' in options:
         build_target += '-DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a'
@@ -141,7 +141,7 @@ def get_build_step(link, type, options = []):
         suffix = [link, type]
 
     if 'newSDK' in options:
-        suffix.append('10.11')
+        suffix.append('10.12')
         target = 'all'
 
     if 'scan-build' in options:


### PR DESCRIPTION
When targeting the 10.11 SDK some features for C++17 are not supported on macOS