### PR TITLE
Drop support for 32-bit architectures in CI

### DIFF
--- a/builders.py
+++ b/builders.py
@@ -66,13 +66,9 @@ def get_builders():
     import paths
 
     return [
-        make_builder('windows-vc15-32', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc15path, 'x86', True, True),
         make_builder('windows-vc15-64', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc15path, 'amd64', True, True),
-        make_builder('windows-vc16-32', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc16path, 'x86', True, True),
         make_builder('windows-vc16-64', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc16path, 'amd64', True, True),
-        make_builder('windows-vc17-32', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc17path, 'x86', True, True),
         make_builder('windows-vc17-64', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc17path, 'amd64', True, True),
-        make_builder('windows-gcc-810-mingw-32', ['binary1248-windows', 'expl0it3r-windows'], 'MinGW Makefiles', paths.gcc810mingw32path, '', True, True),
         make_builder('windows-gcc-810-mingw-64', ['binary1248-windows', 'expl0it3r-windows'], 'MinGW Makefiles', paths.gcc810mingw64path, '', True, True),
         make_builder('debian-gcc-64', ['binary1248-debian'], 'Unix Makefiles', '', '', True, True),
         make_builder('debian-clang-64', ['binary1248-debian'], 'Unix Makefiles', '', '', True, True),


### PR DESCRIPTION
See https://github.com/SFML/SFML/issues/1930 and https://github.com/SFML/SFML/pull/1931.