### PR TITLE
Remove VS 2017 from the build pipeline

### DIFF
--- a/builders.py
+++ b/builders.py
@@ -66,8 +66,6 @@ def get_builders():
     import paths
 
     return [
-        make_builder('windows-vc15-32', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc15path, 'x86', True, True),
-        make_builder('windows-vc15-64', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc15path, 'amd64', True, True),
         make_builder('windows-vc16-32', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc16path, 'x86', True, True),
         make_builder('windows-vc16-64', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc16path, 'amd64', True, True),
         make_builder('windows-vc17-32', ['binary1248-windows', 'expl0it3r-windows'], 'NMake Makefiles JOM', paths.vc17path, 'x86', True, True),

--- a/paths.py
+++ b/paths.py
@@ -1,8 +1,3 @@
-vc15path = (
-    'C:/Dev/tools;'
-    'C:/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/VC/Auxiliary/Build;'
-)
-
 vc16path = (
     'C:/Dev/tools;'
     'C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Auxiliary/Build;'


### PR DESCRIPTION
VS 2017 doesn't fully support C++17

As discussed in https://github.com/SFML/SFML/pull/1937