### PR TITLE
Add support for DRM/KMS

### DIFF
--- a/builders.py
+++ b/builders.py
@@ -77,6 +77,7 @@ def get_builders():
         make_builder('debian-gcc-64', ['binary1248-debian'], 'Unix Makefiles', '', '', True, True),
         make_builder('debian-clang-64', ['binary1248-debian'], 'Unix Makefiles', '', '', True, True),
         make_builder('raspbian-gcc-armhf', ['expl0it3r-raspbian-armhf'], 'Unix Makefiles', '', '', True, True),
+        make_builder('raspbian-gcc-armhf-drm', ['expl0it3r-raspbian-armhf'], 'Unix Makefiles', '', '', True, True),
         make_builder('android-armeabi-v7a', ['binary1248-android'], 'Unix Makefiles', '', '', True, False),
         make_builder('static-analysis', ['binary1248-debian'], 'Unix Makefiles', '', '', False, False),
         make_builder('coverity', ['binary1248-coverity'], 'Unix Makefiles', '', '', False, False),

--- a/buildfactories.py
+++ b/buildfactories.py
@@ -79,6 +79,9 @@ def get_cmake_step(link, type, options = []):
         build_cxx_compiler += '-DCMAKE_CXX_COMPILER=clang++'
         build_stdlib += '-DCMAKE_CXX_FLAGS="-stdlib=libc++"'
 
+    if 'drm' in options:
+        build_target += '-DSFML_USE_DRM'
+
     configure_command = [
         'cmake',
         '-G',
@@ -495,6 +498,13 @@ def get_build_factory(builder_name):
         steps.extend(get_configuration_build_steps('static', 'debug', ['clang']))
         steps.extend(get_configuration_build_steps('dynamic', 'release', ['clang']))
         steps.extend(get_configuration_build_steps('static', 'release', ['clang']))
+
+        steps.extend(get_artifact_step())
+    elif('drm' in builder_name):
+        steps.extend(get_configuration_build_steps('dynamic', 'debug', ['drm']))
+        steps.extend(get_configuration_build_steps('static', 'debug', ['drm']))
+        steps.extend(get_configuration_build_steps('dynamic', 'release', ['drm']))
+        steps.extend(get_configuration_build_steps('static', 'release', ['drm']))
 
         steps.extend(get_artifact_step())
     else:


### PR DESCRIPTION
Once https://github.com/SFML/SFML/pull/2029 is not only merge into the `2.6.x` branch, but also the `master` branch, we can enable this build.