### PR TITLE
Switch iOS build to use built-in CMake support

### DIFF
--- a/buildfactories.py
+++ b/buildfactories.py
@@ -43,7 +43,6 @@ def get_cmake_step(link, type, options = []):
     frameworks_install_directory = Interpolate('')
     misc_install_directory = Interpolate('')
     macos_architecture = Interpolate('')
-    ios_platform = ''
     suffix = ''
 
     if 'frameworks' in options:
@@ -67,8 +66,7 @@ def get_cmake_step(link, type, options = []):
         build_android_api += '-DCMAKE_ANDROID_API=26'
 
     if 'ios' in options:
-        build_sdk += '-DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/iOS.toolchain.cmake'
-        ios_platform = '-DIOS_PLATFORM=SIMULATOR'
+        build_sdk += '-DCMAKE_SYSTEM_NAME=iOS'
 
     if 'macos' in options:
         install_prefix = Interpolate('-DCMAKE_INSTALL_PREFIX=%(prop:builddir)s/install/Library/Frameworks')
@@ -97,7 +95,6 @@ def get_cmake_step(link, type, options = []):
         '-DSFML_BUILD_EXAMPLES=TRUE',
         Interpolate('-DSFML_BUILD_TEST_SUITE=%(prop:run_tests)s'),
         macos_architecture,
-        ios_platform,
         install_prefix,
         frameworks_install_directory,
         misc_install_directory,


### PR DESCRIPTION
For https://github.com/SFML/SFML/pull/2359 we need to adjust the Build Bot build as well.

What I'm unsure about is, if this change will work for both 2.6.x-based branches and master-branch.