### PR TITLE
Add HarfBuzz and Mbed TLS, update CMake for Coverity Dockerfile

### DIFF
--- a/docker/coverity/Dockerfile
+++ b/docker/coverity/Dockerfile
@@ -15,6 +15,8 @@ RUN DEBIAN_FRONTEND=noninteractive \
     file \
     ninja-build \
     build-essential \
+    libmbedtls-dev \
+    libharfbuzz-dev \
     libfreetype-dev \
     libx11-dev \
     libxrandr-dev \
@@ -41,14 +43,14 @@ RUN DEBIAN_FRONTEND=noninteractive \
     && rm -rf /var/lib/apt/lists/*
 
 # CMake
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.30.4/cmake-3.30.4.tar.gz \
-    && tar xzf cmake-3.30.4.tar.gz \
-    && cd cmake-3.30.4 \
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.31.8/cmake-3.31.8.tar.gz \
+    && tar xzf cmake-3.31.8.tar.gz \
+    && cd cmake-3.31.8 \
     && ./bootstrap --parallel=$(nproc) \
     && make -j $(nproc) install \
     && cmake --version \
     && cd .. \
-    && rm -rf cmake-3.30.4*
+    && rm -rf cmake-3.31.8*
 
 # pipx
 RUN rm /usr/lib/python3.*/EXTERNALLY-MANAGED \


### PR DESCRIPTION
The Coverity Dockerfile also needs the new and upcoming dependency. Aligned the CMake version with the other Dockerfiles.

See failing build: https://ci.sfml-dev.org/#/builders/6/builds/517